### PR TITLE
Fix undeclared identifier error

### DIFF
--- a/src/util/time.h
+++ b/src/util/time.h
@@ -6,9 +6,17 @@
 #define NS_PER_SECOND (1000000000)
 #define NS_PER_MS (1000000)
 
+#if defined(TIME_UTC)
+    #define _UNIXTIME_GET(tp) timespec_get(tp, TIME_UTC)
+#elif defined(CLOCK_REALTIME)
+    #define _UNIXTIME_GET(tp) clock_gettime(CLOCK_REALTIME, tp)
+#else
+    #error cannot find function to get unix time
+#endif
+
 #define NOW() ({\
     struct timespec ts;\
-    timespec_get(&ts, TIME_UTC);\
+    _UNIXTIME_GET(&ts);\
     ((ts.tv_sec * NS_PER_SECOND) + ts.tv_nsec);})
 
 #endif


### PR DESCRIPTION
Following error occurs on my Mac:

```
clang -o src/gfx/window.o -c src/gfx/window.c -std=c11 -O3 -g -Wall -Wextra -Wpedantic -Wstrict-aliasing -Wno-pointer-arith -Wno-newline-eof -Wno-unused-parameter -Wno-gnu-statement-expression -Wno-gnu-compound-literal-initializer -Wno-gnu-zero-variadic-macro-arguments -Ilib/cglm/include -Ilib/glad/include -Ilib/glfw/include -Ilib/stb -Ilib/noise -fbracket-depth=1024
...
src/gfx/window.c:69:25: error: use of undeclared identifier 'TIME_UTC'
src/gfx/../util/time.h:11:23: note: expanded from macro 'NOW'
    timespec_get(&ts, TIME_UTC);\
                      ^
...
3 warnings and 3 errors generated.
make: *** [src/gfx/window.o] Error 1
```

Use alternative `clock_gettime` function to resolve issue.

See: https://en.cppreference.com/w/c/chrono/timespec_get#Notes

Related to #39