### PR TITLE
Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,6 @@ $(BIN)/game: $(OBJ) | $(BIN)
 	$(CC) -o $@ -MMD -c $< $(CFLAGS)
 
 clean:
-	rm -rf $(BIN) $(OBJ)
+	rm -rf $(BIN) $(OBJ) $(OBJ:.o=.d)
 
 -include $(OBJ:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -20,26 +20,36 @@ SRC  = $(wildcard src/**/*.c) $(wildcard src/*.c) $(wildcard src/**/**/*.c) $(wi
 OBJ  = $(SRC:.c=.o)
 BIN = bin
 
-.PHONY: all clean
+.PHONY: all clean libs game run dirs
 
-all: dirs libs game
+game: $(BIN)/game
 
-libs:
-	cd lib/cglm && cmake . -DCGLM_STATIC=ON && make
+run: $(BIN)/game
+	$<
+
+libs: lib/cglm/libcglm.a lib/glad/src/glad.o lib/glfw/src/libglfw3.a lib/noise/libnoise.a
+
+lib/cglm/libcglm.a:
+	cd lib/cglm && cmake . -DCGLM_STATIC=ON && $(MAKE)
+
+lib/glad/src/glad.o:
 	cd lib/glad && $(CC) -o src/glad.o -Iinclude -c src/glad.c
-	cd lib/glfw && cmake . && make
-	cd lib/noise && make
 
-dirs:
-	mkdir -p ./$(BIN)
+lib/glfw/src/libglfw3.a:
+	cd lib/glfw && cmake . && $(MAKE)
 
-run: all
-	$(BIN)/game
+lib/noise/libnoise.a:
+	cd lib/noise && $(MAKE)
 
-game: $(OBJ)
-	$(CC) -o $(BIN)/game $^ $(LDFLAGS)
+dirs: $(BIN)
 
-%.o: %.c
+$(BIN):
+	mkdir -p -- $@
+
+$(BIN)/game: $(OBJ) | $(BIN)
+	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)
+
+%.o: %.c | libs
 	$(CC) -o $@ -c $< $(CFLAGS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ $(BIN)/game: $(OBJ) | $(BIN)
 	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)
 
 %.o: %.c | libs
-	$(CC) -o $@ -c $< $(CFLAGS)
+	$(CC) -o $@ -MMD -c $< $(CFLAGS)
 
 clean:
 	rm -rf $(BIN) $(OBJ)
+
+-include $(OBJ:.o=.d)


### PR DESCRIPTION
1. Updated CGLM which seems to fix a lot of people's issues with mismatched vector types
2. Gave `make` a clearer chain of dependencies and the files we expect from them re. library compilation
3. Moved the `game` target up to default position and removed `all`
4. Gave the game an order-only dependency on the `bin` directory (meaning it doesn't get rebuilt every time if that isn't necessary)
5. Used the compiler's dependency tracking (`-MMD`, supported by at least gcc and clang) to allow incremental compilation

It's not perfect (I haven't properly inspected the dependencies of the libraries and triggered recompilations of those where necessary) but it should be enough to enable parallel builds and somewhat reliable incremental compilation.